### PR TITLE
Some site improvements

### DIFF
--- a/src/main/resources/md/css/layouts/blog.css
+++ b/src/main/resources/md/css/layouts/blog.css
@@ -103,6 +103,7 @@ h3 {
 .post-title {
     font-size: 2em;
     color: #222;
+    margin-top: 50px;
     margin-bottom: 0.2em;
 }
 .post-avatar {
@@ -119,6 +120,14 @@ h3 {
     color: #999;
     font-size: 90%;
     margin: 0;
+}
+
+a.post-title-link {
+    color: inherit;
+}
+a.post-title-link:hover,
+a.post-title-link:focus {
+    text-decoration: none;
 }
 
 .post-category {
@@ -182,7 +191,7 @@ h3 {
         padding: 2em 3em 0;
         margin-left: 10%;
     }
-    
+
 
     .header {
         text-align: left;
@@ -241,10 +250,6 @@ h3 {
   margin-top: 35px;
 }
 
-.post-title {
-  margin-top: 50px;
-}
-
 .pub-date {
   color: #939292;
   font-size: 16px;
@@ -268,4 +273,3 @@ a.next-page {
   margin-left: 10px;
   margin-right: 10px;
 }
-

--- a/src/main/resources/md/episodes/series-97.md
+++ b/src/main/resources/md/episodes/series-97.md
@@ -4,7 +4,7 @@ audio.length=100433760
 page=https://scalalaz.ru/series-97.html
 date=2021-02-14
 ----
-![episode 97](https://scalalaz.ru/img/episode97.png)
+![episode 97](/img/episode97.png)
 
 * 00:00:47 [Scala 3 Tech Report (Softwaremill)](https://softwaremill.com/ebooks/scala-3-tech-report/)
 * 00:45:30 Checked exceptions in scala 3

--- a/src/main/twirl/main_page.scala.html
+++ b/src/main/twirl/main_page.scala.html
@@ -6,7 +6,7 @@
 @template(title) {
  @for( p <- pages ) {
     <section>
-        <h1 class="post-title">@p.episode.settings.title</h1>
+        <h1 class="post-title"><a href="@p.fileName" class="post-title-link">@p.episode.settings.title</a></h1>
         <p class="pub-date">
             Опубликовано: @p.episode.settings.ISODate
         </p>

--- a/src/main/twirl/template.scala.html
+++ b/src/main/twirl/template.scala.html
@@ -42,10 +42,6 @@
                                 <li><a href="https://www.patreon.com/scalalalaz">Patreon</a></li>
                                 <li><a href="mailto:info@@scalalaz.ru">Или пиши нам вот сюда: info@@scalalaz.ru</a></li>
                             </ul>
-                            <br/>
-                            <ul>
-                                <li><a href="https://scalanews.org/">Scala News</a></li>
-                            </ul>
                         </div>
                     </ul>
                 </div>
@@ -54,7 +50,7 @@
             <nav class="nav">
                 <div class="pure-menu custom-restricted-width">
                     <ul class="pure-menu-list">
-                        <div class="toc">                          
+                        <div class="toc">
                             <ul>
                                 <li><a href="https://discord.gg/RnugmrU">Discord - Чат подкаста</a></li>
                             </ul>


### PR DESCRIPTION
* Сделал заголовки выпусков кликабельными. Меня всегда бесило, что я не могу просто кликнуть в заголовок и перейти на страницу выпуска.
* Убрал ссылку на Scala News. Там сейчас уже ничего нет.
* Вместо абсолютного пути к картинке выпуска попробовал использовать относительный. Чтобы можно было локально тестировать. Пока я применил это только к последнему выпуску.