### PR TITLE
Pagination reworked

### DIFF
--- a/src/main/resources/md/css/layouts/blog.css
+++ b/src/main/resources/md/css/layouts/blog.css
@@ -115,7 +115,7 @@ h3 {
 }
 
 .posts {
-    padding-bottom: 2em;
+    padding-bottom: 3em;
 }
 
 .post {
@@ -243,23 +243,50 @@ a.post-title-link:focus {
   font-size: 16px;
 }
 
-a.prev-page {
-  color: #ff5265;
-  position: absolute;
-  right: 0;
-}
-
-a.next-page {
-  color: #ff5265;
-  position: absolute;
-  left: 0;
-}
-
 .pagination {
-  position: relative;
-  margin-top: 25px;
-  margin-left: 10px;
-  margin-right: 10px;
+    margin-top: 50px;
+    padding-bottom: 2em;
+}
+
+.pagination-buttons {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
+
+.pagination-button {
+    float: left;
+    border: 1px solid #aaa;
+    border-right: none;
+    height: 36px;
+    width: 36px;
+    line-height: 36px;
+    font-size: 16px;
+    text-align: center;
+    color: #333;
+}
+.pagination-button:first-child {
+    border-radius: 3px 0 0 3px;
+}
+.pagination-button:last-child {
+    border-right: 1px solid #aaa;
+    border-radius: 0 3px 3px 0;
+}
+.pagination-button.active {
+    border: none;
+    background: #aaa;
+    color: #fff;
+}
+
+.pagination-link {
+    display: block;
+    width: 100%;
+    height: 100%;
+    color: #333;
+}
+.pagination-link:hover {
+    text-decoration: none;
+    background: #eee;
 }
 
 .gcse-search-wrapper {

--- a/src/main/scala/ru/scalalaz/gen/package.scala
+++ b/src/main/scala/ru/scalalaz/gen/package.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 Scalalaz Podcast Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.scalalaz
+
+package object gen {
+  type FileName = String
+}

--- a/src/main/scala/ru/scalalaz/gen/writers/Pagination.scala
+++ b/src/main/scala/ru/scalalaz/gen/writers/Pagination.scala
@@ -16,21 +16,86 @@
 
 package ru.scalalaz.gen.writers
 
-case class Pagination[A](prev: Option[A], current: A, next: Option[A])
-
+case class Pagination[A](
+  buttons: Seq[Pagination.Button[A]]
+)
 object Pagination {
 
-  def forList[A](list: List[A]): List[Pagination[A]] =
-    forList[A](None, list)
+  sealed trait Button[+A]
+  object Button {
+    case class CurrentPage[A](value: A) extends Button[A]
+    case class Page[A](value: A) extends Button[A]
+    case object Ellipsis extends Button[Nothing]
+  }
 
-  private def forList[A](prev: Option[A], list: List[A]): List[Pagination[A]] = {
-    list match {
-      case Nil => Nil
-      case x :: Nil =>
-        List(Pagination(prev, x, None))
-      case x :: y :: _ =>
-        List(Pagination(prev, x, Some(y))) ++ forList(Some(x), list.tail)
+  case class Config(
+    maxNextButtons: Int = 3,
+    maxEdgeButtons: Int = 2,
+  ) {
+    def allFitsSize: Int = maxNextButtons + maxEdgeButtons + 2
+  }
+
+  def from[A](
+    currentPageIndex: Int,
+    allPages: Seq[A],
+    config: Config = Config(),
+  ): Pagination[A] = {
+    val size = allPages.size
+
+    if (size == 0) {
+      Pagination[A](List.empty)
+    } else {
+      assert(
+        currentPageIndex >= 0 && currentPageIndex < size,
+        s"Invalid currentPageIndex $currentPageIndex. It should be in the interval [0,${size})."
+      )
+
+      val allButtons: Vector[Button[A]] = allPages.toVector.zipWithIndex.map { case (page, idx) =>
+        if (idx == currentPageIndex) {
+          Button.CurrentPage(page)
+        } else {
+          Button.Page(page)
+        }
+      }
+
+      val buttons: Seq[Button[A]] = if (size <= config.allFitsSize) {
+        allButtons
+      } else {
+        val (beforeCurrent, withCurrent) = allButtons.splitAt(currentPageIndex)
+        val afterCurrent = withCurrent.drop(1)
+
+        val current: Button[A] = withCurrent.head
+
+        val rightFragment = computeRightFragment(afterCurrent, config)
+        val leftFragment = computeRightFragment(beforeCurrent.reverse, config).reverse
+
+        leftFragment ++ Vector(current) ++ rightFragment
+      }
+
+      Pagination(buttons)
     }
   }
 
+  private def computeRightFragment[A](
+    fragment: Vector[Button[A]],
+    config: Config,
+  ): Vector[Button[A]] = {
+    val (nextButtons, afterNextButtons) = fragment.splitAt(config.maxNextButtons)
+
+    val (rightEllipsisButtons, lastButtons) = {
+      if (afterNextButtons.size > config.maxEdgeButtons) {
+        afterNextButtons.splitAt(afterNextButtons.size - config.maxEdgeButtons)
+      } else {
+        (Vector.empty, afterNextButtons)
+      }
+    }
+
+    val rightEllipsis = if (rightEllipsisButtons.size > 1) {
+      Vector(Button.Ellipsis)
+    } else {
+      rightEllipsisButtons
+    }
+
+    nextButtons ++ rightEllipsis ++ lastButtons
+  }
 }

--- a/src/main/twirl/main_page.scala.html
+++ b/src/main/twirl/main_page.scala.html
@@ -1,10 +1,12 @@
 @import ru.scalalaz.gen.writers.EpisodePage
 @import html.template
+@import ru.scalalaz.gen.FileName
+@import ru.scalalaz.gen.writers.Pagination
+@import ru.scalalaz.gen.writers.PageName
 
-@(title: String,
+@(title: FileName,
   pages: Seq[EpisodePage],
-  prev: Option[String],
-  next: Option[String])
+  pagination: Pagination[PageName])
 
 @template(title) {
     @for( p <- pages ) {
@@ -18,13 +20,21 @@
        </section>
     }
     <div class="pagination">
-        @for( link <- prev) {
-            <a href="@link" class="prev-page">Вперед →</a>
+        <ul class="pagination-buttons">
+        @for( button <- pagination.buttons ) {
+            @button match {
+                case Pagination.Button.CurrentPage(pageName) => {
+                    <li class="pagination-button active">@pageName.order</li>
+                }
+                case Pagination.Button.Page(pageName) => {
+                    <li class="pagination-button"><a class="pagination-link" href="/@pageName.file">@pageName.order</a></li>
+                }
+                case Pagination.Button.Ellipsis => {
+                    <li class="pagination-button">...</li>
+                }
+            }
         }
-
-        @for( link <- next) {
-            <a href="@link" class="next-page">← Назад</a>
-        }
+        </ul>
     </div>
 
     <script src="/js/clickable-post-images.js"></script>

--- a/src/test/scala/ru/scalalaz/gen/parsing/PaginationSpec.scala
+++ b/src/test/scala/ru/scalalaz/gen/parsing/PaginationSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Scalalaz Podcast Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.scalalaz.gen.parsing
+
+import org.scalatest.freespec.AnyFreeSpec
+import ru.scalalaz.gen.writers.Pagination
+import ru.scalalaz.gen.writers.Pagination.Button
+
+class PaginationSpec extends AnyFreeSpec {
+
+  "Pagination.from" - {
+    "should be able to construct empty pagination" in {
+      assert(Pagination.from(0, List.empty[Int]) === Pagination[Int](List.empty))
+    }
+
+    "should fail on invalid currentPageIndex" - {
+      "when currentPageIndex is less than 0" in {
+        assertThrows[AssertionError] {
+          Pagination.from(-1, List(1))
+        }
+      }
+
+      "when currentPageIndex is bigger than allPages.size" in {
+        assertThrows[AssertionError] {
+          Pagination.from(2, List(1))
+        }
+      }
+    }
+
+    "should correctly build pagination object" - {
+      testPattern("1!|2|3|4|5|6|7")
+      testPattern("1|2!|3|4|5|6|7")
+      testPattern("1|2|3!|4|5|6|7")
+      testPattern("1|2|3|4!|5|6|7")
+      testPattern("1|2|3|4|5!|6|7")
+      testPattern("1|2|3|4|5|6!|7")
+      testPattern("1|2|3|4|5|6|7!")
+
+      testPattern("1!|2|3|4|.|7|8")
+
+      testPattern("1!|2|3|4|.|14|15")
+      testPattern("1|2!|3|4|5|.|14|15")
+      testPattern("1|2|3!|4|5|6|.|14|15")
+      testPattern("1|2|3|4!|5|6|7|.|14|15")
+      testPattern("1|2|3|4|5!|6|7|8|.|14|15")
+      testPattern("1|2|3|4|5|6!|7|8|9|.|14|15")
+      testPattern("1|2|3|4|5|6|7!|8|9|10|.|14|15")
+      testPattern("1|2|.|5|6|7|8!|9|10|11|.|14|15")
+      testPattern("1|2|.|6|7|8|9!|10|11|12|13|14|15")
+      testPattern("1|2|.|7|8|9|10!|11|12|13|14|15")
+      testPattern("1|2|.|8|9|10|11!|12|13|14|15")
+      testPattern("1|2|.|9|10|11|12!|13|14|15")
+      testPattern("1|2|.|10|11|12|13!|14|15")
+      testPattern("1|2|.|11|12|13|14!|15")
+      testPattern("1|2|.|12|13|14|15!")
+    }
+  }
+
+  private def testPattern(expectedPattern: String): Unit = {
+    s"with pattern $expectedPattern" in {
+      def invalidPattern = throw new RuntimeException(s"Invalid pattern: $expectedPattern")
+
+      val expectedButtons: Vector[Pagination.Button[String]] = {
+        expectedPattern.split('|').toVector.map { section =>
+          if (section.endsWith("!")) {
+            Pagination.Button.CurrentPage(section.dropRight(1))
+          } else if (section == ".") {
+            Pagination.Button.Ellipsis
+          } else {
+            Pagination.Button.Page(section)
+          }
+        }
+      }
+
+      val currentPageIndex = expectedButtons.collectFirst {
+        case Pagination.Button.CurrentPage(value) => value.toIntOption.getOrElse(invalidPattern) - 1
+      }.getOrElse(invalidPattern)
+
+      def toIntValue(button: Button[String]): Int = {
+        (button match {
+          case Button.CurrentPage(value) => value
+          case Button.Page(value) => value
+          case Button.Ellipsis => invalidPattern
+        }).toIntOption.getOrElse(invalidPattern)
+      }
+
+      val first: Int = toIntValue(expectedButtons.head)
+      val last: Int = toIntValue(expectedButtons.last)
+
+      val actual = Pagination.from(currentPageIndex, (first to last).toList.map(_.toString))
+
+      assert(actual == Pagination(expectedButtons))
+    }
+  }
+}


### PR DESCRIPTION
Было
====
![pagination_before](https://user-images.githubusercontent.com/2826500/115186071-3e7ca380-a10b-11eb-869e-0322e1c2734d.png)
Кнопка вперёд у меня почему-то вообще не работала.

Стало
=====
![pagination_after](https://user-images.githubusercontent.com/2826500/115186726-6caeb300-a10c-11eb-837c-452b61096214.png)

Реализация
==========

Пагинация генерируется в процессе сборки страницы и зашивается прям в html. Это значит, что всё это работает без js.

Так как сама реализация оказалась довольно замысловатой, я написал большой тест на логику, где покрываются все кейсы.